### PR TITLE
Fix `torch.cat()` issue when processing large number of documents with `TransformersModelForTokenClassificationNerStep`

### DIFF
--- a/kazu/training/config.py
+++ b/kazu/training/config.py
@@ -45,6 +45,8 @@ class TrainingConfig:
     architecture: str = "bert"
     #: fraction of epoch to complete before evaluations begin
     epoch_completion_fraction_before_evals: float = 0.75
+    #: The random seed to use
+    seed: int = 42
 
 
 @dataclass

--- a/kazu/training/modelling_utils.py
+++ b/kazu/training/modelling_utils.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 from hydra.utils import instantiate
 from omegaconf import DictConfig
@@ -44,6 +44,12 @@ def test_doc_yielder() -> Iterable[Document]:
     )
     doc = Document(sections=[section])
     yield doc
+
+
+def chunks(lst: list[Any], n: int) -> Iterable[list[Any]]:
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
 
 
 def get_label_list(path: PathLike) -> list[str]:

--- a/kazu/training/modelling_utils.py
+++ b/kazu/training/modelling_utils.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import logging
-import random
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -102,26 +101,24 @@ class LSManagerViewWrapper:
         return result
 
     def update(
-        self, test_docs: list[Document], global_step: Union[int, str], has_gs: bool = True
+        self, docs: list[Document], global_step: Union[int, str], has_gs: bool = True
     ) -> None:
         ls_manager = LabelStudioManager(
             headers=self.ls_manager.headers,
             project_name=f"{self.ls_manager.project_name}_test_{global_step}",
         )
-
         ls_manager.delete_project_if_exists()
         ls_manager.create_linking_project()
-        docs_subset = random.sample(test_docs, min([len(test_docs), 100]))
-        if not docs_subset:
+        if not docs:
             logger.info("no results to represent yet")
             return
         if has_gs:
-            side_by_side = self.get_gold_ents_for_side_by_side_view(docs_subset)
+            side_by_side = self.get_gold_ents_for_side_by_side_view(docs)
             ls_manager.update_view(self.view, side_by_side)
             ls_manager.update_tasks(side_by_side)
         else:
-            ls_manager.update_view(self.view, docs_subset)
-            ls_manager.update_tasks(docs_subset)
+            ls_manager.update_view(self.view, docs)
+            ls_manager.update_tasks(docs)
 
 
 def create_wrapper(cfg: DictConfig, label_list: list[str]) -> Optional[LSManagerViewWrapper]:

--- a/kazu/training/train_multilabel_ner.py
+++ b/kazu/training/train_multilabel_ner.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import pickle
+import random
 import shutil
 import tempfile
 from collections import defaultdict
@@ -337,6 +338,7 @@ class Trainer:
         self.label_list = label_list
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
         self.keys_to_use = _select_keys_to_use(self.training_config.architecture)
+        random.seed(training_config.seed)
 
     def _write_to_tensorboard(
         self, global_step: int, main_tag: str, tag_scalar_dict: dict[str, NumericMetric]
@@ -360,7 +362,8 @@ class Trainer:
 
         model_test_docs = self._process_docs(model)
         if self.ls_wrapper:
-            self.ls_wrapper.update(model_test_docs, global_step)
+            sample_test_docs = random.sample(model_test_docs, min([len(model_test_docs), 100]))
+            self.ls_wrapper.update(sample_test_docs, global_step)
 
         all_results, tensorboad_loggables = calculate_metrics(
             epoch_loss, model_test_docs, self.label_list

--- a/kazu/training/train_multilabel_ner.py
+++ b/kazu/training/train_multilabel_ner.py
@@ -47,14 +47,9 @@ from kazu.training.modelling import (
     DebertaForMultiLabelTokenClassification,
     DistilBertForMultiLabelTokenClassification,
 )
+from kazu.training.modelling_utils import chunks
 
 logger = logging.getLogger(__name__)
-
-
-def chunks(lst: list[Any], n: int) -> Iterable[list[Any]]:
-    """Yield successive n-sized chunks from lst."""
-    for i in range(0, len(lst), n):
-        yield lst[i : i + n]
 
 
 class LSManagerViewWrapper:


### PR DESCRIPTION
# The Issue
Noticed a weird problem occurring in the evaluation script when trying to naively process a large number (365) of Kazu documents with the `TransformersModelForTokenClassificationNerStep` step using the `MPS` device. 

The 365 documents used totalled over 14k sections and were being processed with a newly trained 400MB model. Performing this on a Mac M3 with MPS, I saw Python's memory usage peak at 18GB:
![image](https://github.com/user-attachments/assets/03eb123c-4532-47c6-9d88-e8b51557f0ba)
In the end the step failed to predict any entities but without any exceptions thrown. The result was a weird phenomenon inside https://github.com/AstraZeneca/KAZU/blob/main/kazu/steps/ner/hf_token_classification.py:

```
  def get_multilabel_activations(self, loader: DataLoader) -> Tensor:
        """Get a tensor consisting of confidences for labels in a multi label
        classification context.

        :param loader:
        :return:
        """
        with torch.no_grad():
            results = torch.cat(
                tuple(self.model(**batch.to(self.device)).logits for batch in loader)
            ).to(self.device)
        return results.heaviside(torch.tensor([0.0]).to(self.device)).int().to("cpu")
```
Where `torch.cat` was producing a tensor full of zeros, indicating the model has not found any entities. This is likely due to torch.cat exceeding the allocated memory of the device. 

# The Fix
The fix is in two places. Firstly in the evaluate script we now process the documents in batches through the pipeline. However, to stop a user naively processing many documents with the Kazu pipeline and hitting this issue, there is also a fix inside the `TransformersModelForTokenClassificationNerStep`. This offloads the model logits onto CPU before concatenation. 

# Testing Performance
Here we perform the test with the naive call to the step with all the documents at once as before and test the version of `TransformersModelForTokenClassificationNerStep` before and after the change. 

Before the change we observe a peak memory usage of 18GB and it takes 690s to process all the documents. With the new implementation we see a peak memory usage of 4GB and it takes 680s to process all the documents - also fixing the weird issue. Thus there doesn't seem to be any performance degradation in executing `torch.cat` on cpu vs mps. Cuda device was not tested however. 

# General Test for single label classification
A test script with the default model pipeline and Kazu model pack was run as a sanity check. The integration tests will now also be run. 

# Note
There is also a small refactor moving some functions from `train_multilabel_ner` to `modelling_utils`. Individual changes can be seen at commit level.

