### PR TITLE
Refactor Hugging Face model loading

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,6 +270,7 @@ nitpick_ignore = [
     # no sphinx for streamlit
     ("py:class", "streamlit.delta_generator.DeltaGenerator"),
     # vertexai
+    ("py:class", "SafetySettingsType"),
     ("py:class", "vertexai.generative_models._generative_models.SafetySetting"),
     ("py:class", "google.cloud.aiplatform_v1beta1.types.content.HarmCategory"),
     ("py:class", "google.cloud.aiplatform_v1beta1.types.content.SafetySetting.HarmBlockThreshold"),

--- a/kazu/conf/TransformersModelForTokenClassificationNerStep/default.yaml
+++ b/kazu/conf/TransformersModelForTokenClassificationNerStep/default.yaml
@@ -3,10 +3,6 @@ path: ${oc.env:KAZU_MODEL_PACK}/tinybern
 batch_size: 4
 stride: 16
 max_sequence_length: 128
-keys_to_use: #distilbert for token classification doesn't use token_type_ids
-  - input_ids
-  - attention_mask
-  - token_type_ids
 entity_splitter:
   _target_: kazu.steps.ner.entity_post_processing.NonContiguousEntitySplitter
   entity_conditions:

--- a/kazu/conf/TransformersModelForTokenClassificationNerStep/multilabel_biomedBERT.yaml
+++ b/kazu/conf/TransformersModelForTokenClassificationNerStep/multilabel_biomedBERT.yaml
@@ -3,10 +3,6 @@ path: ${oc.env:KAZU_MODEL_PACK}/multilabel_biomedBERT
 batch_size: 2
 stride: 64
 max_sequence_length: 512
-keys_to_use: #distilbert for token classification doesn't use token_type_ids
-  - input_ids
-  - attention_mask
-  - token_type_ids
 entity_splitter:
   _target_: kazu.steps.ner.entity_post_processing.NonContiguousEntitySplitter
   entity_conditions:

--- a/kazu/steps/ner/hf_token_classification.py
+++ b/kazu/steps/ner/hf_token_classification.py
@@ -65,7 +65,7 @@ class TransformersModelForTokenClassificationNerStep(Step):
         stride: int,
         max_sequence_length: int,
         tokenized_word_processor: TokenizedWordProcessor,
-        keys_to_use: Iterable[str],
+        keys_to_use: Optional[Iterable[str]] = None,
         entity_splitter: Optional[NonContiguousEntitySplitter] = None,
         device: str = "cpu",
     ):
@@ -77,11 +77,12 @@ class TransformersModelForTokenClassificationNerStep(Step):
         :param max_sequence_length: passed to HF tokenizers (for splitting long docs)
         :param tokenized_word_processor:
         :param keys_to_use: keys to use from the encodings. Note that this varies depending on the flaour of bert model (e.g. distilbert requires token_type_ids)
+
+            .. deprecated:: No longer used: automatically inferred from the model.
         :param entity_splitter: to detect non-contiguous entities if provided
         :param device: device to run the model on. Defaults to "cpu"
         """
 
-        self.keys_to_use = set(keys_to_use)
         self.device = device
         self.entity_splitter = entity_splitter
         if max_sequence_length % 2 != 0:
@@ -97,6 +98,7 @@ class TransformersModelForTokenClassificationNerStep(Step):
         self.tokeniser: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
             path, config=self.config
         )
+        self.keys_to_use = self.tokeniser.model_input_names
         self.model = AutoModelForTokenClassification.from_pretrained(
             path, config=self.config
         ).eval()

--- a/kazu/training/config.py
+++ b/kazu/training/config.py
@@ -41,8 +41,6 @@ class TrainingConfig:
     device: str
     #: number of workers for dataloader
     workers: int
-    #: architecture to use. Currently supports bert, deberta, distilbert
-    architecture: str = "bert"
     #: fraction of epoch to complete before evaluations begin
     epoch_completion_fraction_before_evals: float = 0.75
     #: The random seed to use
@@ -61,7 +59,5 @@ class PredictionConfig:
     max_sequence_length: int
     #: device to train on
     device: str
-    #: architecture to use. Currently supports bert, deberta, distilbert
-    architecture: str = "bert"
     #: whether to use multilabel token classification
     use_multilabel: bool = True

--- a/kazu/training/evaluate_script.py
+++ b/kazu/training/evaluate_script.py
@@ -25,11 +25,7 @@ from kazu.training.modelling_utils import (
     doc_yielder,
     get_label_list_from_model,
 )
-from kazu.training.train_multilabel_ner import (
-    _select_keys_to_use,
-    calculate_metrics,
-    move_entities_to_metadata,
-)
+from kazu.training.train_multilabel_ner import calculate_metrics, move_entities_to_metadata
 from kazu.utils.constants import HYDRA_VERSION_BASE
 
 
@@ -61,7 +57,6 @@ def main(cfg: DictConfig) -> None:
         tokenized_word_processor=TokenizedWordProcessor(
             labels=label_list, use_multilabel=prediction_config.use_multilabel
         ),
-        keys_to_use=_select_keys_to_use(prediction_config.architecture),
         device=prediction_config.device,
     )
     pipeline = Pipeline(steps=[step])

--- a/kazu/training/modelling.py
+++ b/kazu/training/modelling.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Tuple
+from typing import Any, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -7,6 +7,7 @@ from transformers import (
     DistilBertForTokenClassification,
     BertForTokenClassification,
     PretrainedConfig,
+    PreTrainedModel,
     DebertaV2ForTokenClassification,
 )
 from transformers.modeling_outputs import TokenClassifierOutput, BaseModelOutput
@@ -16,7 +17,7 @@ check_min_version("4.9.0")  # transformers version check
 
 
 def multi_label_forward(
-    model: nn.Module,
+    model: PreTrainedModel,
     outputs: BaseModelOutput,
     return_dict: bool,
     device: torch.device,
@@ -215,7 +216,7 @@ class BertForMultiLabelTokenClassification(BertForTokenClassification):  # type:
 
 
 class AutoModelForMultiLabelTokenClassification:
-    _model_mapping = {
+    _model_mapping: dict[str, type[PreTrainedModel]] = {
         "deberta": DebertaForMultiLabelTokenClassification,
         "distilbert": DistilBertForMultiLabelTokenClassification,
         "bert": BertForMultiLabelTokenClassification,
@@ -225,9 +226,9 @@ class AutoModelForMultiLabelTokenClassification:
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: str,
-        *model_args,
-        **kwargs,
-    ) -> nn.Module:
+        *model_args: Any,
+        **kwargs: Any,
+    ) -> PreTrainedModel:
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
         model_class = cls._model_mapping.get(config.model_type)
 

--- a/kazu/training/predict_script.py
+++ b/kazu/training/predict_script.py
@@ -15,7 +15,6 @@ from kazu.steps.ner.hf_token_classification import (
 from kazu.steps.ner.tokenized_word_processor import TokenizedWordProcessor
 from kazu.training.config import PredictionConfig
 from kazu.training.modelling_utils import create_wrapper, get_label_list_from_model
-from kazu.training.train_multilabel_ner import _select_keys_to_use
 from kazu.utils.constants import HYDRA_VERSION_BASE
 
 
@@ -38,7 +37,6 @@ def main(cfg: DictConfig) -> None:
         stride=prediction_config.stride,
         max_sequence_length=prediction_config.max_sequence_length,
         tokenized_word_processor=TokenizedWordProcessor(labels=label_list, use_multilabel=True),
-        keys_to_use=_select_keys_to_use(prediction_config.architecture),
         device=prediction_config.device,
     )
     pipeline = Pipeline(steps=[step])

--- a/scripts/examples/conf/multilabel_ner_evaluate/default.yaml
+++ b/scripts/examples/conf/multilabel_ner_evaluate/default.yaml
@@ -6,7 +6,6 @@ prediction_config:
   stride: 64
   max_sequence_length: 512
   device: cpu
-  architecture: bert
   use_multilabel: true
 predictions_dir: ???
 css_colors:

--- a/scripts/examples/conf/multilabel_ner_predict/default.yaml
+++ b/scripts/examples/conf/multilabel_ner_predict/default.yaml
@@ -10,7 +10,6 @@ prediction_config:
   stride: 64
   max_sequence_length: 512
   device: cpu
-  architecture: bert
   use_multilabel: true
 css_colors:
   - "#000000" # Black

--- a/scripts/examples/conf/multilabel_ner_training/default.yaml
+++ b/scripts/examples/conf/multilabel_ner_training/default.yaml
@@ -18,7 +18,6 @@ training_config:
   lr_scheduler_warmup_prop: 0.1
   test_overfit: false
   device: mps
-  architecture: bert
   workers: 2
 css_colors:
   - "#000000" # Black


### PR DESCRIPTION
The purpose of this PR is to simplify the loading of Hugging Face models.

- Models are now loaded in a similar way to the [Auto Class](https://huggingface.co/docs/transformers/en/model_doc/auto) pattern from Hugging Face Transformers.
- Hard-coded values for the model `architecture` and input `keys_to_use` have been removed. These values are now automatically inferred from the model itself.
- The `keys_to_use` parameter in `TransformersModelForTokenClassificationNerStep` has been deprecated. This parameter is retained for backwards compatibility, although supplying a value will have no effect.