### PR TITLE
fix: upgrade action which was using the deprecated action `upload-artificat v3`

### DIFF
--- a/.github/workflows/deploy-github-pages.yaml
+++ b/.github/workflows/deploy-github-pages.yaml
@@ -39,7 +39,7 @@ jobs:
         . /tmp/kazu-env/bin/activate
         make -C docs html
     - name: upload pages artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ./docs/_build/html
 


### PR DESCRIPTION
See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ the culprit action used by actions/upload-pages-artifact.